### PR TITLE
Improve seat allocation on semicircle plot

### DIFF
--- a/src/poli_sci_kit/plot/parliament.py
+++ b/src/poli_sci_kit/plot/parliament.py
@@ -25,6 +25,8 @@ def parliament(
     df_seat_lctns=None,
     dsat=default_sat,
     axis=None,
+    legend=False,
+    **kwargs
 ):
     """
     Produces a parliament plot given seat allocations.
@@ -114,11 +116,12 @@ def parliament(
         s=marker_size,
         edgecolor="#D2D2D3",
         ax=axis,
+        legend=legend,
+        **kwargs
     )  # edge color same as legend outline
 
     # Make plot a proportional and remove background axes.
     ax.axis("equal")
     ax.axis("off")
-    ax.legend("off")
 
     return ax

--- a/src/poli_sci_kit/plot/parliament.py
+++ b/src/poli_sci_kit/plot/parliament.py
@@ -104,25 +104,21 @@ def parliament(
     elif style == "semicircle":
         marker = "o"
 
-    if labels is None:
-        labels = list(df_seat_lctns["group"].unique())
-
-    # Loop through groups and plot their allocations.
-    for g, lbl in enumerate(labels):
-        df_subsetted = df_seat_lctns[df_seat_lctns["group"] == lbl]
-
-        ax = sns.scatterplot(
-            data=df_subsetted,
-            x="x_loc",
-            y="y_loc",
-            color=colors[g],
-            marker=marker,
-            s=marker_size,
-            edgecolor="#D2D2D3",
-        )  # edge color same as legend outline
+    # Plot parliament in a scatterplot
+    ax = sns.scatterplot(
+        data=df_seat_lctns,
+        x="x_loc",
+        y="y_loc",
+        hue="group",
+        marker=marker,
+        s=marker_size,
+        edgecolor="#D2D2D3",
+        ax=axis,
+    )  # edge color same as legend outline
 
     # Make plot a proportional and remove background axes.
     ax.axis("equal")
     ax.axis("off")
+    ax.legend("off")
 
     return ax

--- a/src/poli_sci_kit/utils.py
+++ b/src/poli_sci_kit/utils.py
@@ -174,6 +174,9 @@ def gen_parl_points(
         ]  # greater shift for higher rows for more equal spacing
         seats_per_row = [rs + seats_shift[i] for i, rs in enumerate(row_seats)]
 
+        if any(seats <= 0 for seats in seats_per_row):
+            raise Exception(f'Cannot allocate {total_seats} seats into {num_rows} rows. Try a smaller number of rows.')
+
         row_indexes = []
         row_position_indexes = []
         for i, spr in enumerate(seats_per_row):

--- a/src/poli_sci_kit/utils.py
+++ b/src/poli_sci_kit/utils.py
@@ -141,17 +141,20 @@ def gen_parl_points(
             Generates an arc of the parliament plot given a radius and the number of seats.
             """
             angles = np.linspace(start=np.pi, stop=0, num=seats)
-            x_coordinates, y_coordinates = [], []
 
             # Broadcast angles to their corresponding coordinates.
             x_coordinates = list(r * np.cos(angles))
             y_coordinates = list(r * np.sin(angles))
 
-            return x_coordinates, y_coordinates
+            return x_coordinates, y_coordinates, list(angles)
 
-        xs, ys = [], []
+        # Store point coordinates (x, y) and their angles with origin (0, 0)
+        xs, ys, thetas = [], [], []
+
+        # Create a list with radii values for each row
         radii = range(2, 2 + num_rows)
 
+        # Calculate the number of seats each row will have
         row_seats = [int(total_seats / num_rows)] * num_rows
         extra_seat = total_seats - sum(
             row_seats
@@ -174,63 +177,33 @@ def gen_parl_points(
         row_indexes = []
         row_position_indexes = []
         for i, spr in enumerate(seats_per_row):
-            arc_xs, arc_ys = arc_coordinates(radii[i], spr)
+            arc_xs, arc_ys, arc_angles = arc_coordinates(radii[i], spr)
             xs += arc_xs
             ys += arc_ys
+            thetas += arc_angles
             row_indexes += [i] * spr
             # List of lists for position indexes such that they can be accessed by row and position.
             row_position_indexes += [list(range(spr))]
 
-        for i in range(total_seats):
-            df_seat_lctns.loc[i, "x_loc"] = xs[i]
-            df_seat_lctns.loc[i, "y_loc"] = ys[i]
-
+        # Populate dataframe with coordinates, row number and position, and angles
+        df_seat_lctns["x_loc"] = xs
+        df_seat_lctns["y_loc"] = ys
+        df_seat_lctns["theta"] = thetas
         df_seat_lctns["row"] = row_indexes
         df_seat_lctns["row_position"] = [
             item for sublist in row_position_indexes for item in sublist
         ]
 
-        # Index the group and deplete a copy of allocations at its location.
-        group_index = 0
-        seats_to_allocate = allocations.copy()
-        row_index = 0
+        # Generate list of seat labels
+        seat_labels = []
+        for n_seats, label in zip(allocations, labels):
+            seat_labels.extend([label]*n_seats)
 
-        while total_seats > 0:
-            # Assign based on row and the current index within that row.
-            if row_position_indexes[row_index] != []:
-                index_to_assign = [
-                    i
-                    for i in df_seat_lctns.index
-                    if df_seat_lctns.loc[i, "row"] == row_index
-                    and df_seat_lctns.loc[i, "row_position"]
-                    == row_position_indexes[row_index][0]
-                ][0]
+        # Sort plot points by their angle with the origin (0,0)
+        df_seat_lctns.sort_values(by=["theta", "row"], ascending=[False, True], inplace=True)
 
-                df_seat_lctns.loc[index_to_assign, "group"] = labels[group_index]
-
-                total_seats -= 1
-
-                seats_to_allocate[group_index] -= 1
-                if seats_to_allocate[group_index] == 0:
-                    group_index += 1
-
-                row_position_indexes[row_index].pop(0)
-
-                row_index += 1
-                if row_index == num_rows:
-                    row_index = 0
-
-                # Make sure that radii are filled before rows are completed.
-                for i in range(num_rows):
-                    if len(row_position_indexes[i]) < i + 2:
-                        if i != 0:
-                            row_index -= 1
-                        else:
-                            row_index = num_rows - 1
-
-            else:
-                while row_position_indexes[row_index] == []:
-                    row_index += 1
+        # Assign seat labels
+        df_seat_lctns["group"] = seat_labels
 
     elif style == "rectangle":
         x_coordinate = 0
@@ -305,10 +278,10 @@ def gen_parl_points(
             df_seat_lctns.reset_index(inplace=True, drop=True)
 
             # Define the top and bottom rows so they can be filled in order.
-            top_rows = y_coordinates[int((len(y_coordinates) + 1) / 2) :]
-            bottom_rows = y_coordinates[: int((len(y_coordinates) + 1) / 2)]
+            top_rows = y_coordinates[int((len(y_coordinates) + 1) / 2):]
+            bottom_rows = y_coordinates[:int((len(y_coordinates) + 1) / 2)]
 
-            # Find the total seats in each section to be depleated.
+            # Find the total seats in each section to be depleted.
             total_top_seats = 0
             for row in top_rows:
                 total_top_seats += len(df_seat_lctns[df_seat_lctns["y_loc"] == row])
@@ -431,6 +404,9 @@ def swap_parl_allocations(df, row_0, pos_0, row_1, pos_1):
 
     Parameters
     ----------
+        df    : pandas.DataFrame
+            DataFrame containing parliament data
+
         row_0 : int
             The row of one seat to swap.
 
@@ -477,7 +453,7 @@ def hex_to_rgb(hex_rep):
             An RGB tuple color representation.
     """
     return sRGBColor(
-        *[int(hex_rep[i + 1 : i + 3], 16) for i in (0, 2, 4)], is_upscaled=True
+        *[int(hex_rep[i + 1:i + 3], 16) for i in (0, 2, 4)], is_upscaled=True
     )
 
 
@@ -506,7 +482,7 @@ def rgb_to_hex(rgb_trip):
 
 def scale_saturation(rgb_trip, sat):
     """
-    Changes the saturation of an rgb color.
+    Changes the saturation of rgb color.
 
     Parameters
     ----------

--- a/tests/plot/test_parliament.py
+++ b/tests/plot/test_parliament.py
@@ -12,6 +12,6 @@ def test_semicircle_parl_plot(monkeypatch, allocations):
     plot.parliament(allocations=allocations, style="semicircle")
 
 
-def test_rectangleparl_plot(monkeypatch, allocations):
+def test_rectangle_parl_plot(monkeypatch, allocations):
     monkeypatch.setattr(plt, "show", lambda: None)
     plot.parliament(allocations=allocations, style="rectangle")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_gen_faction_groups():
     ) == [["a", "b", "f"], ["c", "d", "e",]]
 
 
-def test_semiscirled_parl_plot(allocations):
+def test_semicircle_parl_plot(allocations):
     assert list(
         utils.gen_parl_points(
             allocations=allocations, style="semicircle", num_rows=2, speaker=False,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,17 +25,12 @@ def test_gen_faction_groups():
 
 
 def test_semicircle_parl_plot(allocations):
-    assert list(
-        utils.gen_parl_points(
-            allocations=allocations, style="semicircle", num_rows=2, speaker=False,
-        )["row"]
-    ) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    test_df = utils.gen_parl_points(
+        allocations=allocations, style="semicircle", num_rows=2, speaker=False,
+    )
 
-    assert list(
-        utils.gen_parl_points(
-            allocations=allocations, style="semicircle", num_rows=2, speaker=False,
-        )["row_position"]
-    ) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    assert list(test_df["row"]) == [0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    assert list(test_df["row_position"]) == [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 6, 5, 7, 6, 8, 7, 9, 8, 10]
 
     test_df = utils.gen_parl_points(
         allocations=allocations, style="semicircle", num_rows=2, speaker=True,


### PR DESCRIPTION
Fix #20 and #30.

Improve seat allocation by grouping points in the scatterplot based on the angle between them and the origin (0, 0).

Also, raise an exception when seats cannot be properly allocated into the number of rows desired.

Allow users to tweak plot via kwargs.